### PR TITLE
Honor StyleCop setting "Treat Violations as Errors"

### DIFF
--- a/cslib/Implementations/StyleCopLinter.cs
+++ b/cslib/Implementations/StyleCopLinter.cs
@@ -53,7 +53,7 @@ namespace cslib
                     Name = e.Violation.Rule.Name,
                     Code = e.Violation.Rule.CheckId,
                     Message = e.Message,
-                    Severity = e.Warning ? LintSeverity.WARNING : LintSeverity.ERROR
+                    Severity = e.SourceCode.Project.ViolationsAsErrors ? LintSeverity.ERROR : LintSeverity.WARNING
                 };
                 results.Issues.Add(new LintIssue
                 {


### PR DESCRIPTION
This setting does not seem to propagate to the `ViolationEventArgs.Warning` property in case it is set to `FALSE`.
I don't know if `e.Warning` can ever be `TRUE` in a normal StyleCop installation. In my projects every violation was treated as an error by StyleCopLinter, which produced too much warnings when using Phabricator's arc lint command (Errors are always shown, even if the line they are on has not been changed. Warnings are only shown if they where introduced by code changes, which is the behaviour I needed).
Maybe you would wan't to incorporate these changes.
Thanks for the work you put into cstools! It really works great and I use it on a daily basis.

Cheers,

Torben